### PR TITLE
Install missing JS dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,5 +30,8 @@ COPY config.inc.php config/
 COPY plugins-password-config.inc.php plugins/password/config.inc.php
 COPY plugins-password-file.php plugins/password/drivers/file.php
 
+# Install missing JS dependencies
+RUN bin/install-jsdeps.sh
+
 # Keep the db in a volume for persistence
 VOLUME /var/www/db

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,9 +31,7 @@ COPY plugins-password-config.inc.php plugins/password/config.inc.php
 COPY plugins-password-file.php plugins/password/drivers/file.php
 
 # Install missing JS dependencies
-RUN apt-get -qq update && \
-    apt-get install -y unzip file && \
-    apt-get clean && rm -rf /var/lib/apt/lists/*
+RUN cleaninstall unzip file
 RUN bin/install-jsdeps.sh
 
 # Keep the db in a volume for persistence

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,9 @@ COPY plugins-password-config.inc.php plugins/password/config.inc.php
 COPY plugins-password-file.php plugins/password/drivers/file.php
 
 # Install missing JS dependencies
+RUN apt-get -qq update && \
+    apt-get install -y unzip file && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
 RUN bin/install-jsdeps.sh
 
 # Keep the db in a volume for persistence


### PR DESCRIPTION
After building the image with Roundcube v1.3.0 the JS dependencies are missing.

To install them `bin/install-jsdeps.sh` has to be executed.